### PR TITLE
Feat(backend): 35 Added field example to schema load

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -47,12 +47,12 @@ ipcMain.on("async-new-query", async (event, arg) => {
 global.sharedObj = {
   models: [],
   currQuery: {
-    from: "orders",
-    fields: ["order_id", "order_status", "order_date", "customer_id", "first_name", "last_name"],
-    addedTables: ["customers"],
+    from: '',
+    fields: [],
+    addedTables: [],
     group: '',
     where: '',
-    qualifiedFields: ["orders.order_id"],
+    qualifiedFields: [],
     selectedModelsAndFields: []
   }
 };
@@ -105,7 +105,8 @@ const relatedFields = fieldsArr => {
           globalModel.fields.push({
             field_name: field.field_name,
             field_id: field.field_id,
-            field_type: field.field_type
+            field_type: field.field_type,
+            field_example: field.field_example
           });
           return globalModel;
         } else {
@@ -119,7 +120,8 @@ const relatedFields = fieldsArr => {
             {
               field_name: field.field_name,
               field_id: field.field_id,
-              field_type: field.field_type
+              field_type: field.field_type,
+              field_example: field.field_example
             }
           ];
           return globalModel;
@@ -149,7 +151,7 @@ ipcMain.on("async-selected-db-schema", async (event, arg) => {
 
   client
     .query(
-      "SELECT models.model_id, models.model_name, fields.field_name, fields.field_id, fields.field_type FROM models LEFT JOIN fields on models.model_id = fields.model_id WHERE models.database_id = 1"
+      "SELECT models.model_id, models.model_name, fields.field_name, fields.field_id, fields.field_type, fields.field_example FROM models LEFT JOIN fields on models.model_id = fields.model_id WHERE models.database_id = 1"
     )
     .then(res => {
       relatedFields(res.rows);

--- a/src/Aggregate.js
+++ b/src/Aggregate.js
@@ -36,7 +36,8 @@ class Aggregate extends Component {
               field =>
                 field.field_type === "integer" ||
                 field.field_type === "decimal" ||
-                field.field_type === "date"
+                field.field_type === "date" ||
+                field.field_type === "year"
             )
             .map(field => field.field_name);
     this.setState({
@@ -134,6 +135,7 @@ class Aggregate extends Component {
     const globalObj = electron.remote.getGlobal("sharedObj");
     const models = globalObj.models;
     const currQuery = globalObj.currQuery;
+    console.log('currQuery', currQuery)
     const selectedModels = [...currQuery.addedTables];
     selectedModels.push(currQuery.from);
     let selectedFields = [];

--- a/src/Filter.js
+++ b/src/Filter.js
@@ -63,7 +63,8 @@ class Filter extends React.Component {
     const availableFilters =
       fieldToFilter.field_type === "integer" ||
       fieldToFilter.field_type === "decimal" ||
-      fieldToFilter.field_type === "date"
+      fieldToFilter.field_type === "date" ||
+      fieldToFilter.field_type === "year"
         ? Object.keys(this.state.fieldFilterOptions)
         : ["equals", "does not equal"];
     console.log("available filters", availableFilters);


### PR DESCRIPTION
Related to ticket #35  
New seed file will be in slack channel
Adjusted main.js so that "field_example" appears in the initial schema load alongside field_name, field_id, and field_type (picture in slack channel)