### PR TITLE
#36: feat(front) - change table and field presentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6090,11 +6090,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6107,15 +6109,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6218,7 +6223,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6228,6 +6234,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6240,6 +6247,7 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6339,7 +6347,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6349,6 +6358,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6454,6 +6464,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/MakeQuery.js
+++ b/src/MakeQuery.js
@@ -1,13 +1,13 @@
 import React, { Component } from "react";
 import squel from "squel";
-import Selector from './Selector/Selector'
-import SelectTable from './SelectTable'
-import SelectFields from './SelectFields'
+import Selector from "./Selector/Selector";
+import SelectTable from "./SelectTable";
+import SelectFields from "./SelectFields";
 import { Link } from "react-router-dom";
-import FormDialog from './FormDialog'
+import FormDialog from "./FormDialog";
 
 const electron = window.require("electron");
-const sharedObject = electron.remote.getGlobal('sharedObj')
+const sharedObject = electron.remote.getGlobal("sharedObj");
 const Store = window.require("electron-store");
 const store = new Store();
 const ipcRenderer = electron.ipcRenderer;
@@ -32,16 +32,18 @@ class MakeQuery extends Component {
     this.handleSubmit = this.handleSubmit.bind(this);
     this.toggleView = this.toggleView.bind(this);
     this.selectedSlide = this.selectedSlide.bind(this);
-    this.joinStep = this.joinStep.bind(this)
+    this.joinStep = this.joinStep.bind(this);
   }
 
   componentDidMount() {
     const modelName = this.props.location.state.model;
-    const selectedModel = sharedObject.models.find(model => model.model_name === modelName);
+    const selectedModel = sharedObject.models.find(
+      model => model.model_name === modelName
+    );
     const copy = { ...selectedModel };
-    copy.fields = []
-    const schema = sharedObject.models
-    this.setState({ schema, selectedModel, selectedModelsAndFields: [ copy ] });
+    copy.fields = [];
+    const schema = sharedObject.models;
+    this.setState({ schema, selectedModel, selectedModelsAndFields: [copy] });
   }
 
   handleChange(e) {
@@ -51,39 +53,46 @@ class MakeQuery extends Component {
         model => model.model_name === modelName
       );
       const copy = { ...selectedModel };
-      copy.fields = []
+      copy.fields = [];
       const selectedModelsAndFields = [...this.state.selectedModelsAndFields];
-      const [includesSelectedModel] = selectedModelsAndFields.filter(model => model.model_name === modelName)
+      const [includesSelectedModel] = selectedModelsAndFields.filter(
+        model => model.model_name === modelName
+      );
 
       if (!includesSelectedModel) {
-        selectedModelsAndFields.unshift(copy)
+        selectedModelsAndFields.unshift(copy);
         this.toggleView();
-        this.setState({ from: modelName, nextView: false, selectedModel, selectedModelsAndFields });
+        this.setState({
+          from: modelName,
+          nextView: false,
+          selectedModel,
+          selectedModelsAndFields
+        });
       }
-
     } else {
       let newField = e.target.value;
       let fields = [...this.state.fields];
-      const [ includes ] = fields.filter(field => field === newField)
+      const [includes] = fields.filter(field => field === newField);
 
       if (!includes) {
         fields.push(newField);
-        let selectedModelsAndFields = this.state.selectedModelsAndFields
-          .map(table => {
+        let selectedModelsAndFields = this.state.selectedModelsAndFields.map(
+          table => {
             if (this.state.selectedModel.model_name === table.model_name) {
               table.fields.push(newField);
-              return table
+              return table;
             }
-            return table
-          })
+            return table;
+          }
+        );
         this.setState({ fields, selectedModelsAndFields });
       }
     }
   }
 
   toggleView() {
-    const bool = this.state.nextView
-    this.setState({ nextView: !bool })
+    const bool = this.state.nextView;
+    this.setState({ nextView: !bool });
   }
 
   handleSubmit(e) {
@@ -96,71 +105,97 @@ class MakeQuery extends Component {
     ipcRenderer.send("async-new-query", query);
     this.setState({ query });
     store.set("query", query);
-    // this.setState({
-    //   from: "",
-    //   fields: []
-    // })
   }
 
   selectedSlide(modelName) {
-    console.log('here')
     const selectedModel = this.state.schema.find(
       model => model.model_name === modelName
     );
-    this.setState({ selectedModel, nextView: false })
+    this.setState({ selectedModel, nextView: false });
   }
 
   joinStep() {
-    electron.remote.getGlobal('sharedObj').currQuery.selectedModelsAndFields = this.state.selectedModelsAndFields;
-    electron.remote.getGlobal('sharedObj').currQuery.from = this.state.from;
-    electron.remote.getGlobal('sharedObj').currQuery.fields = this.state.fields;
+    electron.remote.getGlobal(
+      "sharedObj"
+    ).currQuery.selectedModelsAndFields = this.state.selectedModelsAndFields;
+    electron.remote.getGlobal("sharedObj").currQuery.from = this.state.from;
+    electron.remote.getGlobal("sharedObj").currQuery.fields = this.state.fields;
+  }
+
+  //func to convert table and field labels to human-readable format
+  //takes an array
+  //no regex necessary (for our sample data set)
+  formatNames(arr) {
+    let nameDict = {};
+    let mod;
+    arr.forEach(elem => {
+      if (elem.includes("_")) {
+        let [first, second] = elem.split("_");
+        mod = `${first.charAt(0).toUpperCase()}${first.slice(
+          1
+        )} ${second.charAt(0).toUpperCase()}${second.slice(1)}`;
+      } else {
+        mod = `${elem.charAt(0).toUpperCase()}${elem.slice(1)}`;
+      }
+      nameDict[elem] = mod;
+    });
+    return nameDict;
   }
 
   render() {
-    const globalObj = electron.remote.getGlobal('sharedObj')
-    console.log('global models', globalObj.models)
-    //one issue: right now, in order to pass selectedData and query as props to RefineQuery and Joins, you need to click Submit - we should change that
-    console.log('next', this.state.nextView)
+    const globalObj = electron.remote.getGlobal("sharedObj");
+    console.log("global models", globalObj.models);
+    console.log("next", this.state.nextView);
     return (
-      <div className='Flex-Container'>
-        <div className='Column Center'>
-          {
-            this.state.nextView ?
-              <SelectTable handleChange={this.handleChange} model={this.state.selectedModel} schema={this.state.schema} />
-              : <SelectFields handleChange={this.handleChange} fields={this.state.selectedModel.fields} schema={this.state.schema} />
-          }
-          <div className='Container'>
-            {
-              this.state.selectedModelsAndFields[0] &&
-              <Selector items={this.state.selectedModelsAndFields} selectedModel={this.state.selectedModel} selectedSlide={this.selectedSlide} />
-            }
+      <div className="Flex-Container">
+        <div className="Column Center">
+          {this.state.nextView ? (
+            <SelectTable
+              handleChange={this.handleChange}
+              model={this.state.selectedModel}
+              schema={this.state.schema}
+              formatTableNames={this.formatNames}
+            />
+          ) : (
+            <SelectFields
+              handleChange={this.handleChange}
+              fields={this.state.selectedModel.fields}
+              schema={this.state.schema}
+              formatFieldNames={this.formatNames}
+            />
+          )}
+          <div className="Container">
+            {this.state.selectedModelsAndFields[0] && (
+              <Selector
+                items={this.state.selectedModelsAndFields}
+                selectedModel={this.state.selectedModel}
+                selectedSlide={this.selectedSlide}
+              />
+            )}
           </div>
-          {
-            !this.state.nextView &&
+          {!this.state.nextView && (
             <div>
               <button
-                type='submit'
-                className='Button'
-                onClick={this.toggleView}>
+                type="submit"
+                className="Button"
+                onClick={this.toggleView}
+              >
                 connect another table
               </button>
             </div>
-          }
+          )}
           <div>
-            {
-              this.state.selectedModelsAndFields.length === 2 &&
+            {this.state.selectedModelsAndFields.length === 2 && (
               <div>
                 <FormDialog onClick={this.joinStep} />
               </div>
-            }
+            )}
           </div>
         </div>
         <div>
           {
             <div>
-              <Link
-                to="/startQuery"
-              >
+              <Link to="/startQuery">
                 <button className="Button">start over</button>
               </Link>
             </div>

--- a/src/SelectFields.js
+++ b/src/SelectFields.js
@@ -1,34 +1,35 @@
-import React from 'react'
+import React from "react";
 
 const SelectFields = props => {
   const handleChange = props.handleChange;
-  const fields = props.fields || []
+  const fields = props.fields || [];
+  const fieldNames = fields.map(elem => elem.field_name);
+  const modFields = props.formatFieldNames(fieldNames);
   return (
-    <div className='Title Height-80'>
-      <div className='Column Center Height-50' >
-        <h1 className='Flex-End Column '>Select Fields</h1>
+    <div className="Title Height-80">
+      <div className="Column Center Height-50">
+        <h1 className="Flex-End Column ">Select Fields</h1>
       </div>
-      <div className='Row-buttons Flex-Wrap'>
+      <div className="Row-buttons Flex-Wrap">
         {fields[0] &&
-          fields.map(field => {
+          Object.keys(modFields).map(field => {
             return (
               <div>
                 <button
-                  className='Button'
+                  className="Button"
                   type="submit"
                   name="fields"
-                  value={field.field_name}
+                  value={field}
                   onClick={handleChange}
                 >
-                  {field.field_name}
+                  {modFields[field]}
                 </button>
               </div>
-            )
-          })
-        }
+            );
+          })}
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default SelectFields
+export default SelectFields;

--- a/src/SelectTable.js
+++ b/src/SelectTable.js
@@ -1,39 +1,44 @@
-import React from 'react'
+import React from "react";
 
 const SelectTable = props => {
-  const { handleChange, model } = props;
+  const { handleChange, model, formatTableNames } = props;
   const relatedModels = model.related_models.map(relatedModel => {
     const found = props.schema.find(model => {
-      return model.model_id === relatedModel.relatedmodel_id
-    })
-    return found
-  })
+      return model.model_id === relatedModel.relatedmodel_id;
+    });
+    return found;
+  });
   relatedModels.filter(x => x);
 
-  return (
-    <div className='Title Height-80'>
-      <div className='Column Center Height-50'  >
-        <h1 className='Flex-End Column'>Select Related Table</h1>
+  const modRelatedModels = formatTableNames(
+    relatedModels.map(elem => elem.model_name)
+  );
+
+  return Object.keys(modRelatedModels).length ? (
+    <div className="Title Height-80">
+      <div className="Column Center Height-50">
+        <h1 className="Flex-End Column">Select Related Table</h1>
       </div>
-      <div className='Row-buttons'>
-        {relatedModels[0] && relatedModels.map(model => {
-          return (
-            <div>
-              <button
-                className='Button'
-                type="submit"
-                name="selectedModel"
-                value={model.model_name}
-                onClick={handleChange}
-              >
-                {model.model_name}
-              </button>
-            </div>
-          );
-        })}
+      <div className="Row-buttons">
+        {relatedModels[0] &&
+          Object.keys(modRelatedModels).map(model => {
+            return (
+              <div>
+                <button
+                  className="Button"
+                  type="submit"
+                  name="selectedModel"
+                  value={model}
+                  onClick={handleChange}
+                >
+                  {modRelatedModels[model]}
+                </button>
+              </div>
+            );
+          })}
       </div>
     </div>
-  )
-}
+  ) : null;
+};
 
-export default SelectTable
+export default SelectTable;

--- a/src/Selector/Selector.js
+++ b/src/Selector/Selector.js
@@ -1,12 +1,12 @@
-import React, { Component } from 'react';
-import Flickity from 'flickity';
+import React, { Component } from "react";
+import Flickity from "flickity";
 
 const itemStyle = {
-  width: '30%',
-  height: '260px',
-  background: 'lightgrey',
-  borderRadius: '5px',
-  margin: '10px'
+  width: "30%",
+  height: "260px",
+  background: "lightgrey",
+  borderRadius: "5px",
+  margin: "10px"
 };
 
 export default class Selector extends Component {
@@ -14,9 +14,9 @@ export default class Selector extends Component {
     super(props);
     this.state = {
       selectedIndex: 0,
-      subSelector: false,
-    }
-    this.appendChange=this.appendChange.bind(this)
+      subSelector: false
+    };
+    this.appendChange = this.appendChange.bind(this);
   }
 
   // flkty = null;
@@ -29,55 +29,55 @@ export default class Selector extends Component {
     if (subSelector) {
       this.setState({
         selectedIndex: items.length,
-        subSelector: true,
+        subSelector: true
       });
     }
 
-    this.initFlickity()
+    this.initFlickity();
     // setTimeout(this.initFlickity, 0);
   }
-
 
   componentWillUnmount() {
     if (this.flkty) {
       this.flkty.destroy();
     }
-  };
+  }
 
-  componentDidUpdate(prevProps, prevState){
-    if(prevProps.items !== this.props.items){
+  componentDidUpdate(prevProps, prevState) {
+    if (prevProps.items !== this.props.items) {
       this.appendChange();
     }
   }
 
   initFlickity = () => {
     const options = {
-      cellSelector: '.item',
+      cellSelector: ".item",
       contain: false,
       initialIndex: this.scrollAt,
       accessibility: false,
       pageDots: false,
       wrapAround: false,
-      prevNextButtons: true,
-    }
+      prevNextButtons: true
+    };
 
     this.flkty = new Flickity(this.wrapper, options);
-    this.flkty.on('dragStart', this.dragStart);
-    this.flkty.on('dragEnd', this.dragEnd);
-    this.flkty.on('scroll', this.onScroll);
-    this.flkty.on('settle', this.onSettle);
-
+    this.flkty.on("dragStart", this.dragStart);
+    this.flkty.on("dragEnd", this.dragEnd);
+    this.flkty.on("scroll", this.onScroll);
+    this.flkty.on("settle", this.onSettle);
   };
 
   onSettle = () => {
     const selectedIndex = this.flkty.selectedIndex;
     if (this.state.selectedIndex !== selectedIndex) {
       this.setState({
-        selectedIndex: selectedIndex,
+        selectedIndex: selectedIndex
       });
     }
-    const modelName = this.flkty.selectedSlide.cells[0].element.innerText.split(' ')[0]
-    this.props.selectedSlide(modelName)
+    const modelName = this.flkty.selectedSlide.cells[0].element.innerText.split(
+      " "
+    )[0];
+    this.props.selectedSlide(modelName);
   };
 
   prevScroll = false;
@@ -90,19 +90,19 @@ export default class Selector extends Component {
     let direction = false;
 
     if (this.prevScroll !== false) {
-      direction = (scroll < this.prevScroll) ? 'right' : 'left';
+      direction = scroll < this.prevScroll ? "right" : "left";
     }
 
     const boundaries = {
-      left: this.scrollAt * (this.state.selectedIndex),
-      right: (this.scrollAt * (this.state.selectedIndex + 1)) - (this.scrollAt / 2),
-    }
+      left: this.scrollAt * this.state.selectedIndex,
+      right: this.scrollAt * (this.state.selectedIndex + 1) - this.scrollAt / 2
+    };
 
     // When you move the slider to the left
-    if (scroll > boundaries.right && direction === 'left') {
-      const next = this.state.selectedIndex += 1;
+    if (scroll > boundaries.right && direction === "left") {
+      const next = (this.state.selectedIndex += 1);
       this.setState({
-        selectedIndex: next,
+        selectedIndex: next
       });
 
       if (sub) {
@@ -111,10 +111,14 @@ export default class Selector extends Component {
     }
 
     // When you move the slider to the right
-    if (scroll < boundaries.left && direction === 'right' && this.state.selectedIndex !== 0) {
-      const prev = this.state.selectedIndex -= 1;
+    if (
+      scroll < boundaries.left &&
+      direction === "right" &&
+      this.state.selectedIndex !== 0
+    ) {
+      const prev = (this.state.selectedIndex -= 1);
       this.setState({
-        selectedIndex: prev,
+        selectedIndex: prev
       });
 
       if (sub) {
@@ -130,7 +134,7 @@ export default class Selector extends Component {
 
     if (updateState) {
       this.setState({
-        selectedIndex: index,
+        selectedIndex: index
       });
     }
   };
@@ -149,32 +153,53 @@ export default class Selector extends Component {
 
   dragEnd = e => {
     this.dragStarted = false;
-    const modelName = this.flkty.selectedSlide.cells[0].element.innerText.split(' ')[0]
-    this.props.selectedSlide(modelName)
+    const modelName = this.flkty.selectedSlide.cells[0].element.innerText.split(
+      " "
+    )[0];
+    this.props.selectedSlide(modelName);
   };
 
-  appendChange(){
+  appendChange() {
     if (this.flkty) {
       this.flkty.destroy();
       this.initFlickity();
     }
   }
 
+  //func to format name of selected table in carousel
+  //takes str, not array, like in rest of query-builder
+  formatTableAndFieldNames = str => {
+    let mod;
+    if (str.includes("_")) {
+      let [first, second] = str.split("_");
+      mod = `${first.charAt(0).toUpperCase()}${first.slice(1)} ${second
+        .charAt(0)
+        .toUpperCase()}${second.slice(1)}`;
+    } else {
+      mod = `${str.charAt(0).toUpperCase()}${str.slice(1)}`;
+    }
+    return mod;
+  };
+
   render() {
     const { items } = this.props;
     return (
       <div>
-        <div ref={ch => this.wrapper = ch} >
-          {items.map(item =>
-            <div  style={itemStyle} className="item">
-              <div className="inner Color">{`${item.model_name} table`}</div>
-              {
-                item.fields.map(category => <div className="inner">{category}</div>)
-              }
+        <div ref={ch => (this.wrapper = ch)}>
+          {items.map(item => (
+            <div style={itemStyle} className="item">
+              <div className="inner Color">{`${this.formatTableAndFieldNames(
+                item.model_name
+              )} Table`}</div>
+              {item.fields.map(category => (
+                <div className="inner">
+                  {this.formatTableAndFieldNames(category)}
+                </div>
+              ))}
             </div>
-          )}
+          ))}
         </div>
       </div>
-    )
+    );
   }
 }

--- a/src/StartQuery.js
+++ b/src/StartQuery.js
@@ -10,7 +10,6 @@ class StartQuery extends Component {
   };
 
   componentDidMount() {
-
     ipcRenderer.send(
       "async-selected-db-schema",
       "SELECT models.model_id, models.model_name, foreignKeys.relatedModel_id, foreignKeys.model_foreign_field , foreignKeys.relatedModel_primary_field FROM models LEFT JOIN foreignKeys on models.model_id = foreignKeys.model_id"
@@ -20,12 +19,38 @@ class StartQuery extends Component {
     });
   }
 
-  componentWillUnmount(){
-    ipcRenderer.removeAllListeners("async-db-schema-reply")
+  componentWillUnmount() {
+    ipcRenderer.removeAllListeners("async-db-schema-reply");
   }
+
+  //func to format field and table names @start of query builder
+  //redefined here b/c of unilateral data flow of react
+  //method to fix could be to pass func to MakeQuery as props via Link - maybe we could switch to using Route instead
+  formatModelAndFieldNames = arr => {
+    let fieldDict = {};
+    let mod;
+    arr.forEach(elem => {
+      if (elem.includes("_")) {
+        let [first, second] = elem.split("_");
+        mod = `${first.charAt(0).toUpperCase()}${first.slice(
+          1
+        )} ${second.charAt(0).toUpperCase()}${second.slice(1)}`;
+      } else {
+        mod = `${elem.charAt(0).toUpperCase()}${elem.slice(1)}`;
+      }
+      fieldDict[elem] = mod;
+    });
+    return fieldDict;
+  };
 
   render() {
     const models = this.state.models;
+    let modModels;
+    models.length
+      ? (modModels = this.formatModelAndFieldNames(
+          models.map(elem => elem.model_name)
+        ))
+      : console.log("no models yet");
 
     return (
       <div className="Height-80 Title Column">
@@ -36,16 +61,17 @@ class StartQuery extends Component {
         </div>
         <div className="Row-buttons Flex-Wrap">
           {models.length > 0
-            ? models.map(model => {
+            ? Object.keys(modModels).map(model => {
                 return (
                   <div>
+
                     <Link
                       to={{
                         pathname: "/makeQuery",
-                        state: { model: model.model_name }
+                        state: { model: model }
                       }}
                     >
-                      <button className="Button">{model.model_name}</button>
+                      <button className="Button">{modModels[model]}</button>
                     </Link>
                   </div>
                 );


### PR DESCRIPTION
* change presentation of tables and fields in query builder to human-readable format
* no regex was necessary - just simple string manipulation

* unfortunately needed to add the same formatting function in StartQuery.js as in MakeQuery.js - I would like to define it once in StartQuery and pass it as props, but using react-router-dom's Link will not allow it, as funcs are not serializable - maybe we can switch to using Route instead?
* formatting function takes an array and generates an object to maintain db data but adjust text for presentation
* in Selector.js, a similar function is defined, but takes a string instead