### PR TITLE
feat(front-end): #34 ToolTips on field name buttons

### DIFF
--- a/src/FieldButtons.js
+++ b/src/FieldButtons.js
@@ -1,0 +1,165 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { withStyles } from "@material-ui/core/styles";
+import Tooltip from "@material-ui/core/Tooltip";
+
+const styles = theme => ({
+  lightTooltip: {
+    background: theme.palette.common.white,
+    color: theme.palette.text.primary,
+    boxShadow: theme.shadows[1],
+    fontSize: 11
+  },
+  arrowPopper: {
+    '&[x-placement*="bottom"] $arrowArrow': {
+      top: 0,
+      left: 0,
+      marginTop: "-0.9em",
+      width: "3em",
+      height: "1em",
+      "&::before": {
+        borderWidth: "0 1em 1em 1em",
+        borderColor: `transparent transparent ${
+          theme.palette.grey[700]
+        } transparent`
+      }
+    },
+    '&[x-placement*="top"] $arrowArrow': {
+      bottom: 0,
+      left: 0,
+      marginBottom: "-0.9em",
+      width: "3em",
+      height: "1em",
+      "&::before": {
+        borderWidth: "1em 1em 0 1em",
+        borderColor: `${
+          theme.palette.grey[700]
+        } transparent transparent transparent`
+      }
+    },
+    '&[x-placement*="right"] $arrowArrow': {
+      left: 0,
+      marginLeft: "-0.9em",
+      height: "3em",
+      width: "1em",
+      "&::before": {
+        borderWidth: "1em 1em 1em 0",
+        borderColor: `transparent ${
+          theme.palette.grey[700]
+        } transparent transparent`
+      }
+    },
+    '&[x-placement*="left"] $arrowArrow': {
+      right: 0,
+      marginRight: "-0.9em",
+      height: "3em",
+      width: "1em",
+      "&::before": {
+        borderWidth: "1em 0 1em 1em",
+        borderColor: `transparent transparent transparent ${
+          theme.palette.grey[700]
+        }`
+      }
+    }
+  },
+  arrowArrow: {
+    position: "absolute",
+    fontSize: 7,
+    width: "3em",
+    height: "3em",
+    "&::before": {
+      content: '""',
+      margin: "auto",
+      display: "block",
+      width: 0,
+      height: 0,
+      borderStyle: "solid"
+    }
+  },
+  button: {
+    margin: theme.spacing.unit
+  }
+});
+
+class FieldButtons extends React.Component {
+  state = {
+    arrowRef: null
+  };
+
+  handleArrowRef = node => {
+    this.setState({
+      arrowRef: node
+    });
+  };
+
+  render() {
+    const { classes } = this.props;
+    return (
+      <div className="Row-buttons Flex-Wrap">
+        {this.props.fields[0] &&
+          Object.keys(this.props.modFields).map(field => {
+            let thisField = this.props.fields.find(
+              elem => elem.field_name === field
+            );
+            let type =
+              thisField.field_type === "varchar"
+                ? "string"
+                : thisField.field_type === "enum"
+                ? "custom code"
+                : thisField.field_type === "zipcode"
+                ? "zip code"
+                : thisField.field_type;
+            let example =
+              type === "string"
+                ? `"${thisField.field_example}"`
+                : thisField.field_example;
+            return (
+              <div>
+                <Tooltip
+                  title={
+                    <React.Fragment>
+                        {
+                            //line break not working
+                        }
+                      {`e.g: ${example}\nType: ${type}`}
+                      <span
+                        className={classes.arrowArrow}
+                        ref={this.handleArrowRef}
+                      />
+                    </React.Fragment>
+                  }
+                  classes={{ popper: classes.arrowPopper }}
+                  PopperProps={{
+                    popperOptions: {
+                      modifiers: {
+                        arrow: {
+                          enabled: Boolean(this.state.arrowRef),
+                          element: this.state.arrowRef
+                        }
+                      }
+                    }
+                  }}
+                >
+                  <button
+                    className="Button"
+                    type="submit"
+                    name="fields"
+                    value={field}
+                    onClick={this.props.handleChange}
+                  >
+                    {this.props.modFields[field]}
+                  </button>
+                </Tooltip>
+              </div>
+            );
+          })}
+      </div>
+    );
+  }
+}
+
+FieldButtons.propTypes = {
+  classes: PropTypes.object.isRequired
+};
+
+export default withStyles(styles)(FieldButtons);

--- a/src/SelectFields.js
+++ b/src/SelectFields.js
@@ -1,4 +1,5 @@
 import React from "react";
+import FieldButtons from "./FieldButtons";
 
 const SelectFields = props => {
   const handleChange = props.handleChange;
@@ -10,24 +11,11 @@ const SelectFields = props => {
       <div className="Column Center Height-50">
         <h1 className="Flex-End Column ">Select Fields</h1>
       </div>
-      <div className="Row-buttons Flex-Wrap">
-        {fields[0] &&
-          Object.keys(modFields).map(field => {
-            return (
-              <div>
-                <button
-                  className="Button"
-                  type="submit"
-                  name="fields"
-                  value={field}
-                  onClick={handleChange}
-                >
-                  {modFields[field]}
-                </button>
-              </div>
-            );
-          })}
-      </div>
+      <FieldButtons
+        fields={fields}
+        modFields={modFields}
+        handleChange={handleChange}
+      />
     </div>
   );
 };


### PR DESCRIPTION
files changed:

SelectFields.js -
moved buttons out into new component to add MaterialUI styling

files added:

FieldButtons.js -
field button component with MaterialUI styles
passed fields, modFields, and handleChange as props from SelectFields

outstanding work:

line break in tool tip text (React.Fragment)
tool tip positioning/styles